### PR TITLE
Remove HTTP(S)_PROXY env if opt.share=False

### DIFF
--- a/scripts/webui.py
+++ b/scripts/webui.py
@@ -2316,6 +2316,8 @@ class ServerLauncher(threading.Thread):
         }
         if not opt.share:
             demo.queue(concurrency_count=opt.max_jobs)
+            if os.environ.get('HTTP_PROXY') is not None: del os.environ['HTTP_PROXY']
+            if os.environ.get('HTTPS_PROXY') is not None: del os.environ['HTTPS_PROXY']
         if opt.share and opt.share_password:
             gradio_params['auth'] = ('webui', opt.share_password)
 


### PR DESCRIPTION
Gradio doesn't honor `NO_PROXY` env, so it will fail to check the localhost and force you to set `share=True` if `HTTP(S)_PROXY` env exists.

When `opt.share==False`, this PR removes the `HTTP(S)_PROXY` env(if they exist) in the current session to make gradio happy, so no need to expose the ui to the public anymore.